### PR TITLE
Fix getter for GnssStatus

### DIFF
--- a/lib/raw_gnss.dart
+++ b/lib/raw_gnss.dart
@@ -41,9 +41,9 @@ class RawGnss {
     return _gnssNavigationMessageEvents!;
   }
 
-  /// Getter for GnssMeasurement events
+  /// Getter for GnssStatus events
   Stream<GnssStatusModel> get gnssStatusEvents {
-    if (_gnssMeasurementEvents == null) {
+    if (_gnssStatusEvents == null) {
       _gnssStatusEvents = _gnssStatusEventChannel.receiveBroadcastStream().map(
           (event) => GnssStatusModel.fromJson(
               (event as Map<dynamic, dynamic>).cast()));


### PR DESCRIPTION
I noticed that listening on the GnssStatus like this: 
```dart
  RawGnss().gnssStatusEvents.listen((e) {});
```
will cause an exception, because ```gnssStatusEvents``` aren't properly initialized here (i.e. the check for a null value is wrong) and thus accessing the null pointer fails.

Therefore I propose this fix. I have also renamed the comment to fit the functionality of getting GnssStatus events.